### PR TITLE
Bump to version 1.3.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.3.1" %}
-{%set sha256 = "3c1f5e438c7f3593c62dd8f639d5949bc599366c5d82b88a21ddf59cca9cf7fc" %}
+{% set version = "1.3.2" %}
+{%set sha256 = "4c039a7960263343ecb709fdaf728cbea4f3b3f08cbe080ac5a9c6e54d629fa6" %}
 
 package:
   name: constructor
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   script: python setup.py install
 
 requirements:


### PR DESCRIPTION
```
2016-08-11   1.3.2:
-------------------
  * bug: allow '-' in package name, when using 'exlcude' key
```