### PR TITLE
Bump to version 1.3.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.3.3" %}
-{%set sha256 = "103623bb1148b175659e81ebaf9f3642349a2fcd456dcf6e573f85b2b6ff2177" %}
+{% set version = "1.3.4" %}
+{%set sha256 = "9a7564309b70ee62bd0762f728ca18c6c7e7504c5723669d85ee0bf97326aec4" %}
 
 package:
   name: constructor


### PR DESCRIPTION
```
2016-09-15   1.3.4:
-------------------
  * add -s option to shell installer to run without executing user-defined
    scripts, basically #44
* allow NSIS 3 to be used to Windows
```