### PR TITLE
Release 2.0.0

### DIFF
--- a/recipe/PR_126.patch
+++ b/recipe/PR_126.patch
@@ -1,0 +1,23 @@
+From c1446149c506adcc6eeabc0fee1b96a5db22b36a Mon Sep 17 00:00:00 2001
+From: Marcel Bargull <marcel.bargull@udo.edu>
+Date: Fri, 3 Nov 2017 15:41:40 +0100
+Subject: [PATCH] remove broken test test_link_idists
+
+---
+ constructor/tests/test_install.py | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git constructor/tests/test_install.py constructor/tests/test_install.py
+index 3023ea1..b41c580 100644
+--- constructor/tests/test_install.py
++++ constructor/tests/test_install.py
+@@ -129,9 +129,6 @@ def test_name_dist(self):
+         self.assertEqual(name_dist('conda-build-1.21.6-py35_0'),
+                          'conda-build')
+ 
+-    def test_link_idists(self):
+-        self.assertRaises(NotImplementedError, link_idists)
+-
+ 
+ def run():
+     suite = unittest.TestSuite()

--- a/recipe/PR_127.patch
+++ b/recipe/PR_127.patch
@@ -1,0 +1,22 @@
+From a6994c516f15387f62b74f69a9922fb4701c4e5a Mon Sep 17 00:00:00 2001
+From: Marcel Bargull <marcel.bargull@udo.edu>
+Date: Fri, 3 Nov 2017 15:51:24 +0100
+Subject: [PATCH] tests: fix osxpkg import
+
+---
+ constructor/tests/__init__.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git constructor/tests/__init__.py constructor/tests/__init__.py
+index 149ef22..e99a1f3 100644
+--- constructor/tests/__init__.py
++++ constructor/tests/__init__.py
+@@ -36,7 +36,7 @@ def main():
+         shar.read_header_template()
+ 
+     if sys.platform == 'darwin':
+-        from .osxpkg import OSX_DIR
++        from ..osxpkg import OSX_DIR
+         assert len(os.listdir(OSX_DIR)) == 6
+ 
+     test_parser.test_1()

--- a/recipe/PR_128.patch
+++ b/recipe/PR_128.patch
@@ -1,0 +1,24 @@
+From 1e499b1190523b02c4f47d9adb397398a0730af5 Mon Sep 17 00:00:00 2001
+From: Marcel Bargull <marcel.bargull@udo.edu>
+Date: Fri, 3 Nov 2017 16:00:54 +0100
+Subject: [PATCH] tests: fix test_imaging: set *_image_text
+
+---
+ constructor/tests/test_imaging.py | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git constructor/tests/test_imaging.py constructor/tests/test_imaging.py
+index deb4cff..6470a58 100644
+--- constructor/tests/test_imaging.py
++++ constructor/tests/test_imaging.py
+@@ -8,6 +8,10 @@ def test_write_images():
+     tmp_dir = tempfile.mkdtemp()
+ 
+     info = {'name': 'test', 'version': '0.3.1'}
++    for key in ('welcome_image_text', 'header_image_text'):
++        if key not in info:
++            info[key] = info['name']
++
+     write_images(info, tmp_dir)
+ 
+     shutil.rmtree(tmp_dir)

--- a/recipe/PR_129.patch
+++ b/recipe/PR_129.patch
@@ -1,0 +1,23 @@
+From cf5541ac88bfeb4c8275f71c0f8f94cdcd7bf8cb Mon Sep 17 00:00:00 2001
+From: John Kirkham <kirkhamj@janelia.hhmi.org>
+Date: Fri, 3 Nov 2017 11:39:18 -0400
+Subject: [PATCH] Import os in tests
+
+Later in the file `os.listdir` is used as part of the macOS tests, but
+is not being imported. This fixes that.
+---
+ constructor/tests/__init__.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git constructor/tests/__init__.py constructor/tests/__init__.py
+index e99a1f3..0056e7c 100644
+--- constructor/tests/__init__.py
++++ constructor/tests/__init__.py
+@@ -6,6 +6,7 @@
+ 
+ from __future__ import absolute_import, division, print_function
+ 
++import os
+ from os.path import dirname
+ import sys
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,19 @@ source:
   fn: constructor-{{ version }}.tar.gz
   url: https://github.com/conda/constructor/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    #################################################################
+    # Applying some patches to the tests pulled from upstream PRs.  #
+    #                                                               #
+    # xref: https://github.com/conda/constructor/pull/126           #
+    # xref: https://github.com/conda/constructor/pull/127           #
+    # xref: https://github.com/conda/constructor/pull/128           #
+    # xref: https://github.com/conda/constructor/pull/129           #
+    #################################################################
+    - PR_126.patch
+    - PR_127.patch
+    - PR_128.patch
+    - PR_129.patch
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.5.5" %}
-{%set sha256 = "9dfcb41a178e33c1b813eb449cdbc53640500ff22149e21c3038fb59d87ff44d" %}
+{% set version = "2.0.0" %}
+{%set sha256 = "89d9c015f9cb1ffe75aea66b56eab18f7750f3809e60baadff03eec7d0066665" %}
 
 package:
   name: constructor
@@ -12,17 +12,19 @@ source:
 
 build:
   number: 0
-  script: python setup.py install
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  entry_points:
+    - constructor = constructor.main:main
 
 requirements:
   build:
     - python
+    - setuptools
 
   run:
     - python
-    - libconda
-    - pyyaml
-    - pycosat >=0.6.1
+    - conda
+    - ruamel_yaml
     - pillow >=3.1     # [win]
     - nsis >=3.01      # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,8 @@ requirements:
     - libconda
     - pyyaml
     - pycosat >=0.6.1
-    - pillow >=3.1  # [win]
-    - nsis >=3.01   # [win]
+    - pillow >=3.1     # [win]
+    - nsis >=3.01      # [win]
 
 test:
   imports:


### PR DESCRIPTION
Makes a few changes based on upstream. Also bumps the version to 2.0.0. Changelog follows.

```
2017-11-01   2.0.0:
-------------------
  * COMMON:
    - Add support for channel remapping
    - Make sure $PREFIX/envs is created by the installers
    - Fallback to cat if more is not available
    - Allow company name to be specified in construct.yaml
    - Add feature to check file duplicates across dists
    - Switch requirements to conda, ruamel_yaml
    - Add write_condarc option
    - Don't assume that channel keys will always be available
    - Parameterize installer name at various locations
    - Add support for pre-populating repodata cache
    - Introduce 'attempt_hardlinks' option
    - Copy pkgs to conda-bld (local) channel and test from there
    - Also add channels to .condarc
    - Remove urljoin import
    - Fix bug when downloading packages
    - Prefer conda via conda_interface instead of libconda
    - Add dry run option
    - Switch to setuptools
    - Remove eval from setup.py, use absolute paths
    - Add customization for welcome and header image texts
    - Add support and examples for aarch64
    - Add basic jinja2 support

  * NSIS:
    - Compute an approx. size for installation
    - Allow more than one vsXXXX runtime, but warn
    - Fix registry key handling
    - disallow installation when any files present in destination folder
    - Fix 'all users/just me' installation handling
    - Parameterize installation location for all users
    - Improve spaces/non-ascii/unicode character handling in nsis installer
    - Extract python and DLLs to %PREFIX%/%randomdir and ./.install from there
    - Fix several aspects of PATH env var management
    - Fix wording in Windows installer
    - Change AddToPath to not be the default
    - Add support for command line installation for Windows
    - Use ctypes for creating hard links on win
    - NSIS: Copy index cache directory
    - Fix issue when using conda to solve on windows
    - Add ability to make nsis verbose
    - Remove menus of all conda envs during uninstall
    - Add ability to provide defaults for custom options

  * PKG:
    - Add support for signing the pkg installer
    - Flip enable_{anywhere,localSystem}

  * SHELL:
    - Warn user if PYTHONPATH env var is set
    - Handle spaces in path to be patched
    - Compress non tarball files into preconda.tar.bz2
    - Standardise header.sh redirects
    - Add -t option to test the installer
    - Use getopt if available, fallback to getopts
    - Add more tests for RUNNING_SHELL
    - Remove bashisms from header.sh, using only POSIX, split tar and bunzip2
```